### PR TITLE
[WIP] Create docker-compose-ready.yml

### DIFF
--- a/3.4/arm/docker-compose-ready.yml
+++ b/3.4/arm/docker-compose-ready.yml
@@ -1,0 +1,18 @@
+moodledb_rpi:
+  image: rotschopf/rpi-postgres:9.5.4
+  container_name: moodledb_rpi
+  ports:
+    - "5432:5432"
+  environment:
+    - POSTGRES_DATABASE=moodle
+    - POSTGRES_USER=moodle
+    - POSTGRES_PASSWORD=moodle
+moodle_rpi:
+  image: treehouses/moodle:arm
+  container_name: moodle_rpi
+  ports:
+    - "8080:80"
+  links:
+    - moodledb_rpi
+  environment:
+    - MOODLE_URL=http://kraken.ole.org:80


### PR DESCRIPTION
A ready-to-use docker-compose with prebuilt docker.

Our current stuff in compressed state takes 204 MB + Postgress  112 MB.

This reduce Postgress from 112 MB to 11 MB compressed.