### PR TITLE
Delete artifact after extraction and gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .DS_Store
-/moodle

--- a/3.4/arm/Dockerfile
+++ b/3.4/arm/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
 RUN wget -O /var/www/moodle-${version}.tar.gz https://github.com/moodle/moodle/archive/v${version}.tar.gz && \
 	rm -rf /var/www/html/ && \
 	cd /var/www && tar xvf moodle-${version}.tar.gz && \
-	rm -rf moodle-${version}.tar.gz && \
+	rm moodle-${version}.tar.gz && \
 	mv /var/www/moodle-${version} /var/www/html && \
 	chown -R www-data:www-data /var/www/html && \
 	chmod +x /etc/apache2/start.sh &&\

--- a/3.4/arm/Dockerfile
+++ b/3.4/arm/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
 RUN wget -O /var/www/moodle-${version}.tar.gz https://github.com/moodle/moodle/archive/v${version}.tar.gz && \
 	rm -rf /var/www/html/ && \
 	cd /var/www && tar xvf moodle-${version}.tar.gz && \
+	rm -rf moodle-${version}.tar.gz && \
 	mv /var/www/moodle-${version} /var/www/html && \
 	chown -R www-data:www-data /var/www/html && \
 	chmod +x /etc/apache2/start.sh &&\

--- a/3.4/x86/Dockerfile
+++ b/3.4/x86/Dockerfile
@@ -15,7 +15,7 @@ RUN wget -O /var/www/moodle-${version}.tar.gz https://github.com/moodle/moodle/a
 	rm -rf /var/www/html/ && \
 	cd /var/www && tar xvf moodle-${version}.tar.gz && \
 	mv /var/www/moodle-${version} /var/www/html && \
-	rm -rf moodle-${version}.tar.gz && \
+	rm  moodle-${version}.tar.gz && \
 	chown -R www-data:www-data /var/www/html && \
 	chmod +x /etc/apache2/start.sh && \
 	mkdir -p /var/www/moodledata && chmod 777 /var/www/moodledata && \

--- a/3.4/x86/Dockerfile
+++ b/3.4/x86/Dockerfile
@@ -15,6 +15,7 @@ RUN wget -O /var/www/moodle-${version}.tar.gz https://github.com/moodle/moodle/a
 	rm -rf /var/www/html/ && \
 	cd /var/www && tar xvf moodle-${version}.tar.gz && \
 	mv /var/www/moodle-${version} /var/www/html && \
+	rm -rf moodle-${version}.tar.gz && \
 	chown -R www-data:www-data /var/www/html && \
 	chmod +x /etc/apache2/start.sh && \
 	mkdir -p /var/www/moodledata && chmod 777 /var/www/moodledata && \


### PR DESCRIPTION
Fix for #20 and #21 

Example images: `treehouses/moodle:x86-pgsql-1.3-SNAPSHOT`


Shrink size from
`latest 214 MB`
to
`x86-pgsql-1.3-SNAPSHOT 170 MB`